### PR TITLE
fixed observables on the frontend to remove unnecessary delay

### DIFF
--- a/frontend/src/api/kanbanAPI.tsx
+++ b/frontend/src/api/kanbanAPI.tsx
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { Observable, interval, from } from "rxjs";
+import { Observable, interval, from, concat, of } from "rxjs";
 import { switchMap } from "rxjs/operators";
 
 const baseUrl = process.env.REACT_APP_API_BASE_URL;
@@ -18,7 +18,7 @@ export default class KanbanAPI {
   }
 
   static getKanbanBoardsObservable(): Observable<any> {
-    return interval(1000).pipe(
+    return concat(of(0), interval(1000)).pipe(
       switchMap(() => {
         return from(KanbanAPI.getKanbanBoards());
       })
@@ -26,7 +26,7 @@ export default class KanbanAPI {
   }
 
   static getKanbanBoardObservable(id: string): Observable<any> {
-    return interval(1000).pipe(
+    return concat(of(0), interval(1000)).pipe(
       switchMap(() => {
         return from(KanbanAPI.getKanbanBoard(id));
       })
@@ -37,7 +37,7 @@ export default class KanbanAPI {
     boardId: string,
     categoryId: string
   ): Observable<any> {
-    return interval(1000).pipe(
+    return concat(of(0), interval(1000)).pipe(
       switchMap(() => {
         return from(KanbanAPI.getKanbanBoardTasks(boardId, categoryId));
       })

--- a/frontend/src/api/taskAPI.tsx
+++ b/frontend/src/api/taskAPI.tsx
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { Observable, interval, from } from "rxjs";
+import { Observable, interval, from, concat, of } from "rxjs";
 import { switchMap } from "rxjs/operators";
 
 const baseUrl = process.env.REACT_APP_API_BASE_URL;
@@ -14,7 +14,7 @@ export default class TaskAPI {
   }
 
   static getTaskCommentsObservable(taskId: string): Observable<any> {
-    return interval(1000).pipe(
+    return concat(of(0), interval(1000)).pipe(
       switchMap(() => {
         return from(TaskAPI.getTaskComments(taskId));
       })
@@ -22,7 +22,7 @@ export default class TaskAPI {
   }
 
   static getTaskAssigneesObservable(taskId: string): Observable<any> {
-    return interval(1000).pipe(
+    return concat(of(), interval(1000)).pipe(
       switchMap(() => {
         return from(TaskAPI.getTaskAssignees(taskId));
       })

--- a/frontend/src/api/userAPI.tsx
+++ b/frontend/src/api/userAPI.tsx
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { Observable, interval, from } from "rxjs";
+import { Observable, interval, from, concat, of } from "rxjs";
 import { switchMap } from "rxjs/operators";
 
 const baseUrl = process.env.REACT_APP_API_BASE_URL;
@@ -10,7 +10,7 @@ export default class UserAPI {
   }
 
   static getUserObservable(id: string): Observable<any> {
-    return interval(1000).pipe(
+    return concat(of(0), interval(1000)).pipe(
       switchMap(() => {
         return from(UserAPI.getUser(id));
       })


### PR DESCRIPTION
Concated timer observables to start the streams of API calls at time 0 rather than waiting 1000ms for the first API call.